### PR TITLE
fix: Return file information if ls parameter refers to a file

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -193,20 +193,12 @@ func (c *Handler) handleSIZE() {
 func (c *Handler) handleSTATFile() {
 	path := c.absPath(c.param)
 
-	c.writeLine("213-Status follows:")
-	if object, err := c.storager.Stat(path); err == nil {
-		if object.GetMode()&types.ModeDir == 1 {
-			fileInfos, err := c.listFile(path)
-			if err != nil {
-				c.WriteMessage(StatusActionNotTaken, err.Error())
-				return
-			}
-			c.dirList(c.writer, fileInfos)
-		} else {
-			c.writeLine(fileStat(&fileInfo{object}))
-		}
+	fileInfos, err := c.listFile(path)
+	if err != nil {
+		c.WriteMessage(StatusFileActionNotTaken, err.Error())
+		return
 	}
-
+	c.dirList(c.writer, fileInfos)
 	c.writeLine("213 End of status")
 }
 

--- a/tests/ftp_test.go
+++ b/tests/ftp_test.go
@@ -135,8 +135,8 @@ func (t *ftpServerBaseCommandTest) TestListFiles() {
 
 	fileList := tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test",
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test1",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test1",
 	}, fileList)
 }
 
@@ -150,13 +150,13 @@ func (t *ftpServerBaseCommandTest) TestDeleteFile() {
 	tk.MustSuccess(conn, "mkd test1")
 	fileList := tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test",
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test1",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test1",
 	}, fileList)
 	tk.MustSuccess(conn, "RMD test1")
 	fileList = tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test",
 	}, fileList)
 }
 
@@ -169,7 +169,7 @@ func (t *ftpServerBaseCommandTest) TestRenameFile() {
 	tk.Store(conn, "file1", []byte("file1 content"))
 	fileList := tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00  file1",
+		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00 file1",
 	}, fileList)
 
 	tk.MustSuccess(conn, "rnfr file1")
@@ -177,7 +177,7 @@ func (t *ftpServerBaseCommandTest) TestRenameFile() {
 
 	fileList = tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00  test",
+		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00 test",
 	}, fileList)
 
 	tk.MustFailure(conn, "rnto test1")
@@ -192,8 +192,8 @@ func (t *ftpServerBaseCommandTest) TestStoreFile() {
 	tk.Store(conn, "file1", []byte("file1 content"))
 	fileList := tk.List(conn, "")
 	assert.Equal(t.T(), []string{
-		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00  file1",
-		"d--------- 1 ftp ftp            0  Jan  1 00:00  test",
+		"-rwxrwxrwx 1 ftp ftp           13  Jan  1 00:00 file1",
+		"d--------- 1 ftp ftp            0  Jan  1 00:00 test",
 	}, fileList)
 	tk.Send(conn, "size file1").Success("13")
 


### PR DESCRIPTION
- fix a bug that there is an extra space followed the `modtime`.
- if `list` command parameter refers to a file, sends information about that file.