### PR TITLE
test: setup integration test in github workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,43 @@
+name: "Integration Test"
+
+on: [pull_request]
+
+jobs:
+  integration_test:
+    name: Integration Test
+    runs-on: ${{ matrix.os }}
+    env:
+      STORAGE_FTP_INTEGRATION_TEST: on
+      STORAGE_FTP_CREDENTIAL: basic:anonymous:password
+      STORAGE_FTP_ENDPOINT: tcp:127.0.0.1:2121
+
+    strategy:
+      matrix:
+        go: ["1.15", "1.16"]
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Checkout beyong-ftp repository
+        uses: actions/checkout@v2
+        with:
+          path: beyond-ftp
+
+      - name: Checkout go-service-ftp repository
+        uses: actions/checkout@v2
+        with:
+          repository: beyondstorage/go-service-ftp
+          path: go-service-ftp
+
+      - name: Build
+        run: cd beyond-ftp && make build
+
+      - name: Start FTP server
+        run: cd beyond-ftp && bin/beyond-ftp &
+
+      - name: Integration Test
+        run: cd go-service-ftp && make integration_test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: "Integration Test"
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   integration_test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,3 @@ jobs:
 
       - name: Test
         run: make test
-
-      - name: Integration Test
-        run: make integration_test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: Integration Test
+        run: make integration_test

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -7,7 +7,7 @@ service = "memory:///ftp"
 host = "localhost"
 
 # FTP server port.
-port = 21
+port = 2121
 
 # FTP server passive connection host.
 public-host = "127.0.0.1"


### PR DESCRIPTION
- use `go-integration-test` to test the FTP server
- change the port to 2121 in `config/config.example.toml` temporary, after implementing command line flag, change it back.
- only test `memory-storage` for now, should support other storage